### PR TITLE
Refactor: SpotifyController

### DIFF
--- a/hutspot.pro
+++ b/hutspot.pro
@@ -59,7 +59,9 @@ DISTFILES += \
     qml/components/MySearchField.qml \
     qml/components/SectionDelegate.qml \
     qml/components/SortedListModel.qml \
-    qml/components/QueueController.qml
+    qml/components/QueueController.qml \
+    qml/components/SpotifyController.qml \
+    qml/components/PlaybackState.qml
 
 SAILFISHAPP_ICONS = 86x86 108x108 128x128 256x256
 

--- a/qml/components/AlbumTrackContextMenu.qml
+++ b/qml/components/AlbumTrackContextMenu.qml
@@ -1,5 +1,7 @@
 /**
- * Hutspot. Copyright (C) 2018 Willem-Jan de Hoog
+ * Hutspot. 
+ * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -10,13 +12,13 @@ import Sailfish.Silica 1.0
 import "../Util.js" as Util
 
 ContextMenu {
-
+    property var context;
     enabled: Util.isTrackPlayable(track)
     visible: enabled
 
     MenuItem {
         text: qsTr("Play")
-        onClicked: app.playTrack(track)
+        onClicked: app.controller.playTrackInContext(track, context)
     }
 
     MenuItem {

--- a/qml/components/PlaybackState.qml
+++ b/qml/components/PlaybackState.qml
@@ -1,3 +1,10 @@
+/**
+ * Hutspot. 
+ * Copyright (C) 2018 Maciej Janiszewski
+ *
+ * License: MIT
+ */
+
 import QtQuick 2.0
 
 import org.nemomobile.mpris 1.0
@@ -40,10 +47,19 @@ Item {
     property string artistsString: ""
     property string coverArtUrl: ""
 
-    property var device: undefined
+    property var device: {
+        "id": "-1",
+        "is_active": true,
+        "is_private_session": false,
+        "is_restricted": false,
+        "type": "Nothing",
+        "name": "No device",
+        "volume_percent": 100
+    }
     property string repeat_state: "off"
     property bool shuffle_state: false
     property var context: undefined
+    property var contextDetails: undefined
     property int timestamp: 0
     property int progress_ms: 0
     property bool is_playing: false

--- a/qml/components/PlaybackState.qml
+++ b/qml/components/PlaybackState.qml
@@ -1,0 +1,76 @@
+import QtQuick 2.0
+
+import org.nemomobile.mpris 1.0
+import "../Util.js" as Util
+
+Item {   
+    MprisPlayer {
+        id: mprisPlayer
+        serviceName: "hutspot"
+        playbackStatus: is_playing ? Mpris.Playing : Mpris.Paused
+
+        identity: qsTr("Simple Spotify Controller")
+
+        canControl: true
+
+        canPause: true
+        canPlay: true
+        canGoNext: true
+        canGoPrevious: true
+
+        canSeek: false
+
+        onPauseRequested: app.controller.playPause()
+        onPlayRequested: app.controller.play()
+        onPlayPauseRequested: app.controller.playPause()
+        onNextRequested: app.controller.next()
+        onPreviousRequested: app.controller.previous()
+    }
+    onItemChanged: {
+        artistsString = Util.createItemsString(item.artists, qsTr("no artist known"))
+        if (item.album.images.length > 0)
+            coverArtUrl = item.album.images[0].url;
+        else coverArtUrl = "";
+
+        var metadata = {}
+        metadata[Mpris.metadataToString(Mpris.Title)] = item.name
+        metadata[Mpris.metadataToString(Mpris.Artist)] = artistsString
+        mprisPlayer.metadata = metadata
+    }
+    property string artistsString: ""
+    property string coverArtUrl: ""
+
+    property var device: undefined
+    property string repeat_state: "off"
+    property bool shuffle_state: false
+    property var context: undefined
+    property int timestamp: 0
+    property int progress_ms: 0
+    property bool is_playing: false
+    property var item: {
+        "id": -1,
+        "duration_ms": 0,
+        "artists": [],
+        "name": "",
+        "album": {"name": "", "id": -1, "images": []}
+    }
+
+    function nextRepeatState() {
+        if (repeat_state === "off")
+            return "context"
+        else if (repeat_state === "context")
+            return "track";
+        return "off";
+    }
+
+    function importState(state) {
+        device = state.device;
+        repeat_state = state.repeat_state;
+        shuffle_state = state.shuffle_state;
+        context = state.context;
+        timestamp = state.timestamp;
+        progress_ms = state.progress_ms;
+        is_playing = state.is_playing;
+        item = state.item;
+    }
+}

--- a/qml/components/QueueController.qml
+++ b/qml/components/QueueController.qml
@@ -1,3 +1,11 @@
+/**
+ * Hutspot. 
+ * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
+ *
+ * License: MIT
+ */
+
 import QtQuick 2.0
 
 import "../Spotify.js" as Spotify
@@ -88,7 +96,7 @@ Item {
 
             // If not yet playing the Queue Playlist then do that
             if(app.playingPage.currentId !== queuePlaylistId) {
-                app.playContext({uri: queuePlaylistUri})
+                app.controller.playContext({uri: queuePlaylistUri})
                 return
             }
 
@@ -96,9 +104,9 @@ Item {
             // ToDo dont use _IsPlaying
             if(!app.playingPage._isPlaying) {
                 if(app.playingPage.currentSnapshotId === queuePlaylistSnapshotId)
-                    app.pause()
+                    app.controller.playPause()
                 else
-                    app.playContext({uri: queuePlaylistUri})
+                    app.controller.playContext({uri: queuePlaylistUri})
                 return
             }
 
@@ -108,7 +116,7 @@ Item {
             case 'AddedTrack':
                 // if not yet playing we can start
                 if(!app.playingPage.playbackState.is_playing)
-                    app.playContext({uri: queuePlaylistUri})
+                    app.controller.playContext({uri: queuePlaylistUri})
                 else {
                     // we cannot restart. it would cause hickups.
                     // since we only allow add or replace all we wait for the current snapshot to end
@@ -120,10 +128,10 @@ Item {
                 // stop if needed and start, hopefully Spotify uses the latest snapshot
                 if(!app.playingPage.playbackState.is_playing)
                     pause(function(error, data) {
-                        app.playContext({uri: queuePlaylistUri})
+                        app.controller.playContext({uri: queuePlaylistUri})
                     })
                 else
-                    app.playContext({uri: queuePlaylistUri})
+                    app.controller.playContext({uri: queuePlaylistUri})
                 break;
             }*/
         })

--- a/qml/components/SearchResultContextMenu.qml
+++ b/qml/components/SearchResultContextMenu.qml
@@ -29,7 +29,7 @@ ContextMenu {
                 app.controller.playContext(playlist)
                 break;
             case 3:
-                app.controller.playTrackInContext(track)
+                app.controller.playTrack(track)
                 break;
             }
         }

--- a/qml/components/SearchResultContextMenu.qml
+++ b/qml/components/SearchResultContextMenu.qml
@@ -1,5 +1,7 @@
 /**
- * Hutspot. Copyright (C) 2018 Willem-Jan de Hoog
+ * Hutspot. 
+ * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -18,16 +20,16 @@ ContextMenu {
         onClicked: {
             switch(type) {
             case 0:
-                app.playContext(album)
+                app.controller.playContext(album)
                 break;
             case 1:
-                app.playContext(artist)
+                app.controller.playContext(artist)
                 break;
             case 2:
-                app.playContext(playlist)
+                app.controller.playContext(playlist)
                 break;
             case 3:
-                app.playTrack(track)
+                app.controller.playTrackInContext(track)
                 break;
             }
         }

--- a/qml/components/SearchResultListItem.qml
+++ b/qml/components/SearchResultListItem.qml
@@ -1,4 +1,12 @@
-import QtQuick 2.0
+/**
+ * Hutspot. 
+ * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
+ *
+ * License: MIT
+ */
+ 
+ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 import "../Util.js" as Util
@@ -144,7 +152,9 @@ Row {
         var s = "";
         switch(dataModel.type) {
         case Util.SpotifyItemType.Album:
-            return Util.getYearFromReleaseDate(dataModel.album.release_date)
+            if (dataModel.album)
+                return Util.getYearFromReleaseDate(dataModel.album.release_date)
+            return ""
         case Util.SpotifyItemType.Artist:
             if(typeof(dataModel.following) !== 'undefined') {
                if(dataModel.following)

--- a/qml/components/SpotifyController.qml
+++ b/qml/components/SpotifyController.qml
@@ -1,0 +1,241 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import "../Spotify.js" as Spotify
+
+
+Item {
+    PlaybackState {
+        id: playbackState
+    }
+
+    function getCoverArt(state, default_value) {
+        if (state.coverArtUrl !== "")
+            return state.coverArtUrl;
+        return default_value;
+    }
+
+    property alias playbackState: playbackState
+    property alias devices: devicesModel
+
+    ListModel {
+        id: devicesModel
+    }
+
+    Timer {
+        id: handleRendererInfo
+        interval: 1000
+        onRunningChanged: if (running) refreshCount = 0
+        running: playbackState.is_playing || (app.state === Qt.ApplicationActive || cover.status === Cover.Active)
+        property int refreshCount: 0
+        repeat: true
+        onTriggered: {
+            // pretend progress (ms), refresh() will set the actual value
+            if (playbackState.is_playing) {
+                if (playbackState.progress_ms < playbackState.item.duration_ms) {
+                    playbackState.progress_ms += 1000
+                } else playbackState.progress_ms = playbackState.item.duration_ms
+            }
+
+            // also reload playbackState if we haven't done it in a long time
+            if (++refreshCount >= 5) {
+                refreshPlaybackState()
+                refreshCount = 0
+            }
+        }
+    }
+
+    Connections {
+        target: app
+        onStateChanged: {
+            if (app.state === Qt.ApplicationActive) {
+                app.controller.reloadDevices();
+            }
+        }
+    }
+
+    Connections {
+        target: spotify
+        onLinkingSucceeded: {
+            Spotify._accessToken = spotify.getToken()
+            Spotify._username = spotify.getUserName()
+            refreshPlaybackState();
+            reloadDevices();
+        }
+    }
+
+    Timer {
+        id: timer
+        function setTimeout(cb, delayTime) {
+            interval = delayTime;
+            repeat = false;
+            triggered.connect(cb);
+            triggered.connect(function() {
+                triggered.disconnect(cb); // This is important
+            });
+            start();
+        }
+    }
+
+    function setVolume(volume) {
+        var value = Math.round(volume);
+        Spotify.setVolume(value, function(error, data) {
+            if (!error) {
+                playbackState.device.volume_percent = value;
+            }
+        })
+    }
+
+    function reloadDevices() {
+        Spotify.getMyDevices(function(error, data) {
+            if (data) {
+                try {
+                    devicesModel.clear();
+                    for (var i=0; i < data.devices.length; i++) {
+                        devicesModel.append(data.devices[i]);
+                        if (data.devices[i].is_active)
+                            playbackState.device = data.devices[i]
+                    }
+                } catch (err) {
+                    console.log(err)
+                }
+            } else {
+                console.log("No Data for getMyDevices")
+            }
+        })
+    }
+
+    function delayedRefreshPlaybackState() {
+        // for some reason we need to wait
+        // thx spotify
+        handleRendererInfo.refreshCount = 0
+        timer.setTimeout(function () {
+            refreshPlaybackState();
+        }, 300)
+    }
+
+    function next(callback) {
+        // TODO: use playback queue to find out what happens next!
+        // exciting!
+        Spotify.skipToNext({}, function(error, data) {
+            if (callback)
+                callback(error, data)
+            delayedRefreshPlaybackState()
+        })
+    }
+
+    function previous(callback) {
+        Spotify.skipToPrevious({}, function(error, data) {
+            if (callback)
+                callback(error, data)
+            delayedRefreshPlaybackState()
+        })
+    }
+
+    function play(callback) {
+        Spotify.play({}, function(error, data) {
+            if(!error) {
+                playbackState.is_playing = true;
+            }
+            if (callback) callback(error, data)
+        })
+    }
+
+    function pause(callback) {
+        Spotify.pause({}, function(error, data) {
+            if(!error) {
+                playbackState.is_playing = false;
+            }
+            if (callback) callback(error, data)
+        })
+    }
+
+    function playPause(callback) {
+        if (playbackState.is_playing)
+            pause(callback);
+        else
+            play(callback);
+    }
+
+    function setRepeat(value, callback) {
+        Spotify.setRepeat(value, {}, function(error, data) {
+            if (!error) {
+                playbackState.repeat_state = value;
+                delayedRefreshPlaybackState();
+            }
+
+            if (callback) callback(error, data)
+        })
+    }
+
+    function setShuffle(value, callback) {
+        Spotify.setShuffle(value, {}, function(error, data) {
+            if (!error) {
+                playbackState.shuffle_state = value;
+                delayedRefreshPlaybackState();
+            }
+
+            if (callback) callback(error, data)
+        })
+    }
+
+    function refreshPlaybackState() {
+        Spotify.getMyCurrentPlaybackState({}, function (error, state) {
+            if (state) {
+                playbackState.importState(state)
+            }
+        });
+        reloadDevices();
+    }
+
+    function playTrack(track) {
+        Spotify.play({
+            'device_id': playbackState.device.id,
+            'uris': [track.uri]
+        }, function(error, data) {
+            if(!error) {
+                playbackState.item = track
+                refreshPlaybackState();
+            } else
+                showErrorMessage(error, qsTr("Play Failed"))
+        })
+    }
+
+    function playContext(context) {
+        if (!options) {
+            options = {
+                'device_id': playbackState.device.id,
+                'context_uri': context.uri
+            }
+        } else {
+            options.device_id = playbackState.device.id
+            options.context_uri = context.uri
+        }
+
+        Spotify.play(options, function(error, data) {
+            if (!error) {
+              refreshPlaybackState();
+            } else
+                showErrorMessage(error, qsTr("Play Failed"))
+        })
+    }
+
+    function playTrackInContext(track, context) {
+        if (playbackState.device) {
+            Spotify.play({
+                "device_id": playbackState.device.id,
+                "context_uri": context.uri,
+                "offset": {"uri": track.uri}
+            }, function (error, data) {
+                if (!error) {
+                    playbackState.item = track
+                    refreshPlaybackState();
+                } else {
+                    app.showErrorMessage(error, qsTr("Play failed"))
+                }
+            })
+        } else {
+            // TODO: handle that
+            app.showErrorMessage(error, qsTr("No device selected"))
+        }
+    }
+}

--- a/qml/components/SpotifyController.qml
+++ b/qml/components/SpotifyController.qml
@@ -199,7 +199,7 @@ Item {
         Spotify.getMyCurrentPlaybackState({}, function (error, state) {
             if (state) {
                 playbackState.importState(state)
-                if (state.context.uri !== oldContextId) {
+                if (state.context && state.context.uri !== oldContextId) {
                     var cid = Util.getIdFromURI(playbackState.context.uri)
                     switch (state.context.type) {
                         case 'album':
@@ -218,6 +218,8 @@ Item {
                             })
                             break
                     }
+                } else {
+                    playbackState.contextDetails = undefined
                 }
             }
         });

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -9,12 +10,7 @@ import Sailfish.Silica 1.0
 
 CoverBackground {
     id: cover
-
-    property string defaultImageSource : "image://theme/icon-m-music"
-    property string imageSource : defaultImageSource
-    property string titleText : ""
-    property string albumText : ""
-    property string artistsText : ""
+    property string defaultImageSource: "image://theme/icon-m-music"
 
     Column {
         width: parent.width
@@ -32,68 +28,14 @@ CoverBackground {
 
             Image {
                 id: image
-                width: imageSource === defaultImageSource ? sourceSize.width : parent.width
+                width: source === defaultImageSource ? sourceSize.width : parent.width
                 height: width
                 fillMode: Image.PreserveAspectFit
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
-                source: imageSource
+                source: app.controller.getCoverArt(defaultImageSource, app.controller.playbackState)  // TODO: this hack is just bad
             }
         }
-
-        /*Text {
-            id: titleLabel
-            x: titleLabel.width > cover.width
-               ? parent.width
-               : (parent.width-titleLabel.width) / 2
-            text: titleText.length > 0 ? titleText : qsTr("Hutspot")
-            horizontalAlignment: titleLabel.width > cover.width
-                                 ? Text.AlignLeft
-                                 : Text.AlignHCenter
-            font.pixelSize: Theme.fontSizeSmall
-            color: Theme.primaryColor
-
-            NumberAnimation on x {
-                running: cover.status === Cover.Active
-                         && titleLabel.width > cover.width
-                from: cover.width
-                to: -1 * titleLabel.width //+ cover.width)
-                loops: Animation.Infinite
-                duration: 5000
-            }
-        }
-
-        Text {
-            id: otherLabel
-            x: otherLabel.width > cover.width
-               ? parent.width
-               : (parent.width-otherLabel.width) / 2
-            text: artistsText
-
-            horizontalAlignment: otherLabel.width > cover.width
-                                 ? Text.AlignLeft
-                                 : Text.AlignHCenter
-            font.pixelSize: Theme.fontSizeSmall
-            color: Theme.primaryColor
-
-            NumberAnimation on x {
-                running: cover.status === Cover.Active
-                         && otherLabel.width > cover.width
-                from: cover.width
-                to: -1 * otherLabel.width //+ cover.width)
-                loops: Animation.Infinite
-                duration: 5000
-            }
-        }*/
-
-        /*{
-            var s = ""
-            if(albumText)
-                s += albumText
-            if(artistsText && artistsText.length > 0)
-                s += (s.length > 0 ? ", " : "") + artistsText
-            return s
-        }*/
 
         Rectangle {
             width: parent.width
@@ -104,15 +46,6 @@ CoverBackground {
         Row {
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Theme.paddingMedium
-            /*Image {
-                height: Theme.iconSizeSmall
-                width: height
-                sourceSize.height: Theme.iconSizeSmall
-                sourceSize.width: sourceSize.height
-                smooth: true
-                anchors.verticalCenter: spotifyLabel.verticalCenter
-                source: app.getAppIconSource()
-            }*/
             Label {
                 id: spotifyLabel
                 text: qsTr("Hutspot")
@@ -124,29 +57,22 @@ CoverBackground {
 
             CoverAction {
                 iconSource: "image://theme/icon-cover-previous"
-                onTriggered: app.previous(function(error, data){})
+                onTriggered: app.controller.previous(function(error, data){})
             }
 
             CoverAction {
-                iconSource: app.playing
+                iconSource: app.controller.playbackState.is_playing
                             ? "image://theme/icon-cover-pause"
                             : "image://theme/icon-cover-play"
-                onTriggered: app.pause(function(error, data){})
+                onTriggered: app.controller.playPause(function(error, data){})
             }
 
             CoverAction {
                 iconSource: "image://theme/icon-cover-next"
-                onTriggered: app.next(function(error, data){})
+                onTriggered: app.controller.next(function(error, data){})
             }
 
         }
-    }
-
-    function updateDisplayData(metaData) {
-        titleText = metaData['title']
-        albumText = metaData['album']
-        artistsText = metaData['artist']
-        cover.imageSource = metaData['artUrl'] ? metaData['artUrl'] : defaultImageSource
     }
 }
 

--- a/qml/pages/Album.qml
+++ b/qml/pages/Album.qml
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -70,7 +71,7 @@ Page {
                 onPaintedHeightChanged: height = Math.min(parent.width, paintedHeight)
                 MouseArea {
                      anchors.fill: parent
-                     onClicked: app.playContext(album)
+                     onClicked: app.controller.playContext(album)
                 }
             }
 
@@ -125,9 +126,11 @@ Page {
                 onToggleFavorite: app.toggleSavedTrack(model)
             }
 
-            menu: AlbumTrackContextMenu {}
+            menu: AlbumTrackContextMenu {
+                context: album
+            }
 
-            onClicked: app.playTrack(track)
+            onClicked: app.controller.playTrackInContext(track, album)
         }
 
         VerticalScrollDecorator {}

--- a/qml/pages/Artist.qml
+++ b/qml/pages/Artist.qml
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -75,7 +76,7 @@ Page {
                 onPaintedHeightChanged: height = Math.min(parent.width, paintedHeight)
                 MouseArea {
                        anchors.fill: parent
-                       onClicked: app.playContext(currentArtist)
+                       onClicked: app.controller.playContext(currentArtist)
                 }
             }
 

--- a/qml/pages/Playing.qml
+++ b/qml/pages/Playing.qml
@@ -306,7 +306,6 @@ Page {
                     width: parent.width - durationLabel.width - progressLabel.width
                     minimumValue: 0
                     maximumValue: app.controller.playbackState.item.duration_ms
-                    value: app.controller.playbackState.progress_ms
                     handleVisible: false
                     onPressed: isPressed = true
                     onReleased: {
@@ -314,6 +313,15 @@ Page {
                             app.controller.playbackState.progress_ms = Math.round(value)
                          })
                         isPressed = false
+                    }
+                    Connections {
+                        target: app.controller.playbackState
+                        // cannot use 'value: playbackProgress' since press/drag
+                        // breaks the link between them
+                        onProgress_msChanged: {
+                            if(!progressSlider.isPressed)
+                                progressSlider.value = app.controller.playbackState.progress_ms
+                        }
                     }
                 }
                 Label {
@@ -533,15 +541,17 @@ Page {
     }
 
     function updateForCurrentTrack() {
-        switch(app.controller.playbackState.context.type) {
-        case 'album':
-            updateForCurrentAlbumTrack()
-            break
-        case 'playlist':
-            updateForCurrentPlaylistTrack()
-            break
-        default:
-            break
+        if (app.controller.playbackState.context) {
+            switch(app.controller.playbackState.context.type) {
+            case 'album':
+                updateForCurrentAlbumTrack()
+                break
+            case 'playlist':
+                updateForCurrentPlaylistTrack()
+                break
+            default:
+                break
+            }
         }
     }
 
@@ -620,7 +630,7 @@ Page {
                 pageHeaderDescription = ""
             }
         }
-        onIsPlayingChanged: {
+        onIs_playingChanged: {
             if(!_isPlaying && app.controller.playbackState.is_playing) {
                 if(currentIndex === -1)
                     updateForCurrentTrack()

--- a/qml/pages/Playing.qml
+++ b/qml/pages/Playing.qml
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -19,10 +20,8 @@ Page {
     property string defaultImageSource : "image://theme/icon-l-music"
     property bool showBusy: false
     property string pageHeaderText: qsTr("Playing")
+    property string pageHeaderDescription: ""
 
-    property var playingObject
-    property var playbackState
-    property var contextObject: null
     property bool isContextFavorite: false
 
     property string currentId: ""
@@ -34,7 +33,6 @@ Page {
     property bool showTrackInfo: true
 
     property int currentIndex: -1
-    property int playbackProgress: 0
 
     property int mutedVolume: -1
     property bool muted: false
@@ -74,6 +72,7 @@ Page {
                     id: pHeader
                     width: parent.width
                     title: pageHeaderText
+                    description: pageHeaderDescription
                     anchors.horizontalCenter: parent.horizontalCenter
                     MenuButton {}
                 }
@@ -81,7 +80,7 @@ Page {
                 Image {
                     id: imageItem
                     anchors.horizontalCenter: parent.horizontalCenter
-                    source:  getImage()
+                    source:  app.controller.getCoverArt(defaultImageSource, showTrackInfo)
                     width: parent.width * 0.75
                     height: width
                     fillMode: Image.PreserveAspectFit
@@ -102,12 +101,12 @@ Page {
                     MetaInfoPanel {
                         id: info
                         anchors.top: parent.top
-                        firstLabelText: getFirstLabelText(playbackState, contextObject)
-                        secondLabelText: getSecondLabelText(playbackState, contextObject)
-                        thirdLabelText: getThirdLabelText(playbackState, contextObject)
+                        firstLabelText: getFirstLabelText()
+                        secondLabelText: getSecondLabelText()
+                        thirdLabelText: getThirdLabelText()
 
                         isFavorite: isContextFavorite
-                        onToggleFavorite: toggleSavedFollowed(playbackState, contextObject)
+                        onToggleFavorite: toggleSavedFollowed()
                         onFirstLabelClicked: openMenu()
                         onSecondLabelClicked: openMenu()
                         onThirdLabelClicked: openMenu()
@@ -151,10 +150,10 @@ Page {
                         onClicked: {
                             switch(getContextType()) {
                             case Spotify.ItemType.Album:
-                                app.pushPage(Util.HutspotPage.Album, {album: contextObject}, true)
+                                app.pushPage(Util.HutspotPage.Album, {album: app.controller.playbackState.context}, true)
                                 break
                             case Spotify.ItemType.Track:
-                                app.pushPage(Util.HutspotPage.Album, {album: playingObject.item.album}, true)
+                                app.pushPage(Util.HutspotPage.Album, {album: app.controller.playbackState.item.album}, true)
                                 break
                             }
                         }
@@ -166,13 +165,13 @@ Page {
                         onClicked: {
                             switch(getContextType()) {
                             case Spotify.ItemType.Album:
-                                app.loadArtist(contextObject.artists, true)
+                                app.loadArtist(app.controller.playbackState.contextDetails.artists, true)
                                 break
                             case Spotify.ItemType.Artist:
-                                app.pushPage(Util.HutspotPage.Artist, {currentArtist: contextObject}, true)
+                                app.pushPage(Util.HutspotPage.Artist, {currentArtist: app.controller.playbackState.context}, true)
                                 break
                             case Spotify.ItemType.Track:
-                                app.loadArtist(playingObject.item.artists, true)
+                                app.loadArtist(app.controller.playbackState.item.artists, true)
                                 break
                             }
                         }
@@ -181,7 +180,7 @@ Page {
                         id: viewPlaylist
                         visible: enabled
                         text: qsTr("View Playlist")
-                        onClicked: app.pushPage(Util.HutspotPage.Playlist, {playlist: contextObject}, true)
+                        onClicked: app.pushPage(Util.HutspotPage.Playlist, {playlist: app.controller.playbackState.context}, true)
                     }
                 }
 
@@ -190,8 +189,8 @@ Page {
                     width: parent.width
                     font.pixelSize: Theme.fontSizeSmall
                     wrapMode: Text.Wrap
-                    text:  (playbackState && playbackState.device)
-                            ? qsTr("on: ") + playbackState.device.name + " (" + playbackState.device.type + ")"
+                    text:  (app.controller.playbackState && app.controller.playbackState.device)
+                            ? qsTr("on: ") + app.controller.playbackState.device.name + " (" + app.controller.playbackState.device.type + ")"
                             : qsTr("none")
                 }*/
 
@@ -251,7 +250,7 @@ Page {
                     onToggleFavorite: app.toggleSavedTrack(model)
                 }
 
-                onClicked: app.playTrack(track, contextObject)
+                onClicked: app.controller.playTrackInContext(track, app.controller.playbackState.context)
             }
 
             VerticalScrollDecorator {}
@@ -297,7 +296,7 @@ Page {
                     id: progressLabel
                     font.pixelSize: Theme.fontSizeSmall
                     anchors.verticalCenter: parent.verticalCenter
-                    text: Util.getDurationString(playbackProgress)
+                    text: Util.getDurationString(app.controller.playbackState.progress_ms)
                 }
                 Slider {
                     id: progressSlider
@@ -306,35 +305,22 @@ Page {
                     anchors.verticalCenter: parent.verticalCenter
                     width: parent.width - durationLabel.width - progressLabel.width
                     minimumValue: 0
-                    maximumValue: (playbackState && playbackState.item)
-                                  ? playbackState.item.duration_ms
-                                  : 0
+                    maximumValue: app.controller.playbackState.item.duration_ms
+                    value: app.controller.playbackState.progress_ms
                     handleVisible: false
                     onPressed: isPressed = true
                     onReleased: {
                         Spotify.seek(Math.round(value), function(error, data) {
-                            if(!error)
-                                refreshPlaybackState()
+                            app.controller.playbackState.progress_ms = Math.round(value)
                          })
                         isPressed = false
-                    }
-                    Connections {
-                        target: playingPage
-                        // cannot use 'value: playbackProgress' since press/drag
-                        // breaks the link between them
-                        onPlaybackProgressChanged: {
-                            if(!progressSlider.isPressed)
-                                progressSlider.value = playbackProgress
-                        }
                     }
                 }
                 Label {
                     id: durationLabel
                     font.pixelSize: Theme.fontSizeSmall
                     anchors.verticalCenter: parent.verticalCenter
-                    text: (playbackState && playbackState.item)
-                          ? Util.getDurationString(playbackState.item.duration_ms)
-                          : ""
+                    text: Util.getDurationString(app.controller.playbackState.item.duration_ms)
                 }
             }
 
@@ -355,7 +341,7 @@ Page {
                                  Spotify.setVolume(mutedVolume, function(error, data) {
                                      if(!error) {
                                          volumeSlider.value = mutedVolume
-                                         refreshPlaybackState()
+                                         app.controller.refreshPlaybackState()
                                      }
                                  })
                              } else {
@@ -363,7 +349,7 @@ Page {
                                  Spotify.setVolume(0, function(error, data) {
                                      if(!error) {
                                          volumeSlider.value = 0
-                                         refreshPlaybackState()
+                                         app.controller.refreshPlaybackState()
                                      }
                                  })
                              }
@@ -381,12 +367,11 @@ Page {
                     minimumValue: 0
                     maximumValue: 100
                     handleVisible: false
-                    value: (playbackState && playbackState.device)
-                           ? playbackState.device.volume_percent : 0
+                    value: app.controller.playbackState.device.volume_percent
                     onReleased: {
                         Spotify.setVolume(Math.round(value), function(error, data) {
                             if(!error)
-                                refreshPlaybackState()
+                                app.controller.refreshPlaybackState();
                         })
                     }
                 }
@@ -399,51 +384,36 @@ Page {
 
                 IconButton {
                     width: buttonRow.itemWidth
-                    enabled: app.mprisPlayer.canGoPrevious
+                    // enabled: app.mprisPlayer.canGoPrevious
                     icon.source: "image://theme/icon-m-previous"
-                    onClicked: app.previous(function(error,data) {
-                        if(!error)
-                            refreshPlaybackState()
-                    })
+                    onClicked: app.controller.previous()
                 }
                 IconButton {
                     width: buttonRow.itemWidth
-                    icon.source: app.playing
+                    icon.source: app.controller.playbackState.is_playing
                                  ? "image://theme/icon-cover-pause"
                                  : "image://theme/icon-cover-play"
-                    onClicked: app.pause(function(error,data) {
-                        if(!error)
-                            refreshPlaybackState()
-                    })
+                    onClicked: app.controller.playPause()
                 }
                 IconButton {
                     width: buttonRow.itemWidth
-                    enabled: app.mprisPlayer.canGoNext
+                    // enabled: app.mprisPlayer.canGoNext
                     icon.source: "image://theme/icon-m-next"
-                    onClicked: app.next(function(error,data) {
-                        if(!error)
-                            refreshPlaybackState()
-                    })
+                    onClicked: app.controller.next()
                 }
                 IconButton {
                     width: buttonRow.itemWidth
-                    icon.source: (playbackState && playbackState.repeat_state)
+                    icon.source: (app.controller.playbackState && app.controller.playbackState.repeat_state)
                                  ? "image://theme/icon-m-repeat?" + Theme.highlightColor
                                  : "image://theme/icon-m-repeat"
-                    onClicked: app.setRepeat(checked, function(error,data) {
-                        if(!error)
-                            refreshPlaybackState()
-                    })
+                    onClicked: app.controller.setRepeat(checked)
                 }
                 IconButton {
                     width: buttonRow.itemWidth
-                    icon.source: (playbackState && playbackState.shuffle_state)
+                    icon.source: (app.controller.playbackState && app.controller.playbackState.shuffle_state)
                                  ? "image://theme/icon-m-shuffle?" + Theme.highlightColor
                                  : "image://theme/icon-m-shuffle"
-                    onClicked: app.setShuffle(checked, function(error,data) {
-                        if(!error)
-                            refreshPlaybackState()
-                    })
+                    onClicked: app.controller.setShuffle(checked)
                 }
             }
         }
@@ -454,125 +424,81 @@ Page {
         height: controlPanel.height
     }
 
-    property int failedAttempts: 0
-    property int refreshCount: 0
-    Timer {
-        id: handleRendererInfo
-        interval: 1000;
-        running: app.playing
-        repeat: true
-        onTriggered: {
-            if(++refreshCount>=5) {
-                refreshPlaybackState()
-                refreshCount = 0
-            }
-            // pretend progress (ms), refreshPlaybackState() will set the actual value
-            if(playbackState.item && playbackProgress < playbackState.item.duration_ms)
-                playbackProgress += 1000
-        }
-    }
-
-    function getImage() {
-        if(showTrackInfo || !playbackState.context)
-            return (playingObject && playingObject.item)
-                   ? playingObject.item.album.images[0].url
-                   : defaultImageSource
-
-        if(contextObject === null)
-            return defaultImageSource
-
-        switch(playbackState.context.type) {
-        case 'album':
-            return contextObject.album.images[0].url
-        case 'artist':
-            return contextObject.artist.images[0].url
-        case 'playlist':
-            return contextObject.images[0].url
-        }
-        return defaultImageSource
-    }
-
-    function getFirstLabelText(playbackState) {
+    function getFirstLabelText() {
         var s = ""
-        if(playbackState === undefined)
+        if(app.controller.playbackState === undefined)
              return s
-        if(!playbackState.context || showTrackInfo)
-            return playbackState.item ? playbackState.item.name : ""
-        if(contextObject === null)
+        if(!app.controller.playbackState.context || showTrackInfo)
+            return app.controller.playbackState.item ? app.controller.playbackState.item.name : ""
+        if(app.controller.playbackState.context === null)
             return s
-        switch(playbackState.context.type) {
-        case 'album':
-            return contextObject.album.name
-        case 'artist':
-            return contextObject.artist.name
-        case 'playlist':
-            return contextObject.name
-        }
-        return s
+        return app.controller.playbackState.contextDetails.name
     }
 
-    function getSecondLabelText(playbackState, contextObject) {
+    function getSecondLabelText() {
         var s = ""
-        if(playbackState === undefined)
+        if(app.controller.playbackState === undefined)
              return s
-        if(!playbackState.context || showTrackInfo) {
+        if(!app.controller.playbackState.context || showTrackInfo) {
             // no context (a single track?)
-            if(playbackState.item && playbackState.item.album) {
-                s += playbackState.item.album.name
-                s += ", " + Util.getYearFromReleaseDate(playbackState.item.album.release_date)
+            if(app.controller.playbackState.item && app.controller.playbackState.item.album) {
+                s += app.controller.playbackState.item.album.name
+                if (app.controller.playbackState.item.album.release_date)
+                    s += ", " + Util.getYearFromReleaseDate(app.controller.playbackState.item.album.release_date)
             }
             return s
         }
-        if(contextObject === null)
+        if(app.controller.playbackState.context === null)
             return s
-        switch(playbackState.context.type) {
+        switch(app.controller.playbackState.context.type) {
         case 'album':
-            s += Util.createItemsString(contextObject.artists, qsTr("no artist known"))
+            s += Util.createItemsString(app.controller.playbackState.contextDetails.artists, qsTr("no artist known"))
             break
         case 'artist':
-            s += Util.createItemsString(contextObject.genres, qsTr("no genre known"))
+            s += Util.createItemsString(app.controller.playbackState.contextDetails.genres, qsTr("no genre known"))
             break
         case 'playlist':
-            s+= contextObject.description
+            s+= app.controller.playbackState.contextDetails.description
             break
         }
         return s
     }
 
-    function getThirdLabelText(playbackState, contextObject) {
+    function getThirdLabelText() {
         var s = ""
-        if(playbackState === undefined)
+        if(app.controller.playbackState === undefined)
              return s
-        if(!playbackState.context || showTrackInfo) {
+        if(!app.controller.playbackState.context || showTrackInfo) {
             // no context (a single track?)
-            if(playbackState.item && playbackState.item.artists)
-                s += Util.createItemsString(playbackState.item.artists, qsTr("no artist known"))
+            if(app.controller.playbackState.item && app.controller.playbackState.item.artists)
+                s += Util.createItemsString(app.controller.playbackState.item.artists, qsTr("no artist known"))
             return s
         }
-        if(!contextObject)
+        if(!app.controller.playbackState.contextDetails)
             return
-        switch(playbackState.context.type) {
+        switch(app.controller.playbackState.context.type) {
         case 'album':
-            if(contextObject.tracks)
-                s += contextObject.tracks.total + " " + qsTr("tracks")
-            else if(contextObject.album_type === "single")
+            if(app.controller.playbackState.contextDetails.tracks)
+                s += app.controller.playbackState.contextDetails.tracks.total + " " + qsTr("tracks")
+            else if(app.controller.playbackState.contextDetails.album_type === "single")
                 s += "1 " + qsTr("track")
-            s += ", " + Util.getYearFromReleaseDate(contextObject.release_date)
-            if(contextObject.genres && contextObject.genres.lenght > 0)
-                s += ", " + Util.createItemsString(contextObject.genres, "")
+            if (app.controller.playbackState.contextDetails.release_date)
+                s += ", " + Util.getYearFromReleaseDate(app.controller.playbackState.contextDetails.release_date)
+            if(app.controller.playbackState.contextDetails.genres && app.controller.playbackState.contextDetails.genres.lenght > 0)
+                s += ", " + Util.createItemsString(app.controller.playbackState.contextDetails.genres, "")
             break
         case 'artist':
-            if(contextObject.followers && contextObject.followers.total > 0)
-                s += Util.abbreviateNumber(contextObject.followers.total) + " " + qsTr("followers")
+            if(app.controller.playbackState.contextDetails.followers && app.controller.playbackState.contextDetails.followers.total > 0)
+                s += Util.abbreviateNumber(app.controller.playbackState.contextDetails.followers.total) + " " + qsTr("followers")
             break
         case 'playlist':
-            s += contextObject.tracks.total + " " + qsTr("tracks")
-            s += ", " + qsTr("by") + " " + contextObject.owner.display_name
-            if(contextObject.followers && contextObject.followers.total > 0)
-                s += ", " + Util.abbreviateNumber(contextObject.followers.total) + " " + qsTr("followers")
-            if(contextObject["public"])
+            s += app.controller.playbackState.contextDetails.tracks.total + " " + qsTr("tracks")
+            s += ", " + qsTr("by") + " " + app.controller.playbackState.contextDetails.owner.display_name
+            if(app.controller.playbackState.contextDetails.followers && app.controller.playbackState.contextDetails.followers.total > 0)
+                s += ", " + Util.abbreviateNumber(app.controller.playbackState.contextDetails.followers.total) + " " + qsTr("followers")
+            if(app.controller.playbackState.context["public"])
                 s += ", " +  qsTr("public")
-            if(contextObject.collaborative)
+            if(app.controller.playbackState.contextDetails.collaborative)
                 s += ", " +  qsTr("collaborative")
             break
         }
@@ -580,22 +506,19 @@ Page {
     }
 
     function getContextType() {
-        if(!playbackState || !playbackState.context || !contextObject) {
-            if(playingObject && playingObject.item)
-                return Spotify.ItemType.Track
+        if(!app.controller.playbackState || !app.controller.playbackState.item)
             return -1
-        }
-        switch(playbackState.context.type) {
-        case 'album':
-            return Spotify.ItemType.Album
-        case 'artist':
-            return Spotify.ItemType.Artist
-        case 'playlist':
-            return Spotify.ItemType.Playlist
-        }
-        if(playingObject && playingObject.item)
-            return Spotify.ItemType.Track
-        return -1
+
+        if (app.controller.playbackState.context)
+            switch(app.controller.playbackState.context.type) {
+            case 'album':
+                return Spotify.ItemType.Album
+            case 'artist':
+                return Spotify.ItemType.Artist
+            case 'playlist':
+                return Spotify.ItemType.Playlist
+            }
+        return Spotify.ItemType.Track
     }
 
     function updateForCurrentAlbumTrack() {
@@ -610,7 +533,7 @@ Page {
     }
 
     function updateForCurrentTrack() {
-        switch(playbackState.context.type) {
+        switch(app.controller.playbackState.context.type) {
         case 'album':
             updateForCurrentAlbumTrack()
             break
@@ -672,101 +595,47 @@ Page {
 
     // try to detect end of playlist play
     property bool _isPlaying: false
-    onPlaybackStateChanged: {
-        if(playbackState === undefined)
-            return
-
-        if(!_isPlaying && playbackState.is_playing) {
-            if(currentIndex === -1)
-                updateForCurrentTrack()
-            console.log("Started Playing")
-        } else if(_isPlaying && !playbackState.is_playing) {
-            console.log("Stopped Playing")
-            pluOnStopped()
-        }
-
-        _isPlaying = playbackState.is_playing
-    }
-
-    function refreshPlaybackState() {
-        var i;
-
-        Spotify.getMyCurrentPlaybackState({}, function(error, data) {
-            if(data) {
-                playbackState = data
-                if(playbackState.context) {
-                    var cid = Util.getIdFromURI(playbackState.context.uri)
-                    // If id changed we need to refresh.
-                    if(currentId !== cid) {
-                        currentId = cid
-                        contextObject = null
-                        switch(playbackState.context.type) {
-                        case 'album':
-                            Spotify.getAlbum(cid, {}, function(error, data) {
-                                contextObject = data
-                                pageHeaderText = qsTr("Playing Album")
-                            })
-                            loadAlbumTracks(cid)
-                            break
-                        case 'artist':
-                            Spotify.getArtist(cid, {}, function(error, data) {
-                                contextObject = data
-                                pageHeaderText = qsTr("Playing Artist")
-                            })
-                            break
-                        case 'playlist':
-                            tracksInfo = []
-                            Spotify.getPlaylist(cid, {}, function(error, data) {
-                                contextObject = data
-                                if(data)
-                                    currentSnapshotId = data.snapshot_id
-                                console.log("Now playing snaphot: " + data.snapshot_id)
-                                pageHeaderText = qsTr("Playing Playlist")
-                            })
-                            loadPlaylistTracks(app.id, cid)
-                            loadPlaylistTrackInfo()
-                            break
-                        default:
-                            pageHeaderText = qsTr("Playing Album")
-                            break
-                        }
-                    }
-                } else {
-                    // no context (a single track?)
-                    currentId = playbackState.item.id
-                    contextObject = null
-                    pageHeaderText = qsTr("Playing")
+    Connections {
+        target: app.controller.playbackState
+        onItemChanged: {
+            if (app.controller.playbackState.context) {
+                switch (app.controller.playbackState.context.type) {
+                    case 'album':
+                        pageHeaderDescription = app.controller.playbackState.item.album.name
+                        break
+                    case 'artist':
+                        pageHeaderDescription = app.controller.playbackState.artistsString
+                        break
+                    case 'playlist':
+                        pageHeaderDescription = app.controller.playbackState.contextDetails.name
+                        //loadPlaylistTracks(app.id, cid)
+                        break
+                    default:
+                        pageHeaderDescription = ""
+                        break
                 }
-
-                playbackProgress = playbackState.progress_ms
-                app.playing = playbackState.is_playing
-
-                // we have a connection
-                failedAttempts = 0
             } else {
-                // lost connection
-                if(++failedAttempts >= 3) {
-                    showErrorMessage(null, qsTr("Connection lost with Spotify servers"))
-                    app.playing = false
-                    searchModel.clear()
-                }
+                // no context (a single track?)
+                currentId = app.controller.playbackState.item.id
+                pageHeaderDescription = ""
+            }
+        }
+        onIsPlayingChanged: {
+            if(!_isPlaying && app.controller.playbackState.is_playing) {
+                if(currentIndex === -1)
+                    updateForCurrentTrack()
+                console.log("Started Playing")
+            } else if(_isPlaying && !app.controller.playbackState.is_playing) {
+                console.log("Stopped Playing")
+                pluOnStopped()
             }
 
-        })
-
-        Spotify.getMyCurrentPlayingTrack({}, function(error, data) {
-            if(data) {
-                playingObject = data
-                app.newPlayingTrackInfo(data.item)
-                currentTrackId = playingObject.item.id
-                currentTrackUri = playingObject.item.uri
-            }
-        })
-
+            _isPlaying = app.controller.playbackState.is_playing
+        }
     }
 
     function reloadTracks() {
-        switch(playbackState.context.type) {
+        switch(app.controller.playbackState.context.type) {
         case 'album':
             loadAlbumTracks(currentId)
             break
@@ -841,34 +710,34 @@ Page {
         })
     }
 
-    function toggleSavedFollowed(playbackState, contextObject) {
-        if(!playbackState || !playbackState.context || !contextObject)
+    function toggleSavedFollowed() {
+        if(!app.controller.playbackState.context)
             return
-        switch(playbackState.context.type) {
+        switch(app.controller.playbackState.context.type) {
         case 'album':
-            app.toggleSavedAlbum(contextObject, isContextFavorite, function(saved) {
+            app.toggleSavedAlbum(app.controller.playbackState.context, isContextFavorite, function(saved) {
                 isContextFavorite = saved
             })
             break
         case 'artist':
-            app.toggleFollowArtist(contextObject, isContextFavorite, function(followed) {
+            app.toggleFollowArtist(app.controller.playbackState.context, isContextFavorite, function(followed) {
                 isContextFavorite = followed
             })
             break
         case 'playlist':
-            app.toggleFollowPlaylist(contextObject, isContextFavorite, function(followed) {
+            app.toggleFollowPlaylist(app.controller.playbackState.context, isContextFavorite, function(followed) {
                 isContextFavorite = followed
             })
             break
         default: // track?
-            if(playingObject && playingObject.item) { // Note uses globals
+            if (app.controller.playbackState.item) { // Note uses globals
                 if(isContextFavorite)
-                    app.unSaveTrack(playingObject.item, function(error,data) {
+                    app.unSaveTrack(app.controller.playbackState.item, function(error,data) {
                         if(!error)
                             isContextFavorite = false
                     })
                 else
-                    app.saveTrack(playingObject.item, function(error,data) {
+                    app.saveTrack(app.controller.playbackState.item, function(error,data) {
                         if(!error)
                             isContextFavorite = true
                     })
@@ -911,17 +780,9 @@ Page {
     Connections {
         target: app
 
-        onHasValidTokenChanged: refreshPlaybackState()
-
-        onNewPlayingTrackInfo: {
-            // track change?
-            if(currentTrackId !== track.id)
-                refreshPlaybackState()
-        }
-
         onPlaylistEvent: {
             if(getContextType() !== Spotify.ItemType.Playlist
-               || contextObject.id !== event.playlistId)
+               || app.controller.playbackState.contextDetails.id !== event.playlistId)
                 return
 
             // When a plylist is modified while being played the modifications
@@ -939,11 +800,11 @@ Page {
                 // in theory it has been added at the end of the list
                 // so we could load the info and add it to the model but ...
                 loadPlaylistTracks(app.id, currentId)
-                if(_isPlaying) {
+                if(app.controller.playbackState.is_playing) {
                     waitForEndOfSnapshot = true
                     waitForEndSnapshotData.uri = event.uri
                     waitForEndSnapshotData.snapshotId = event.snapshotId
-                    waitForEndSnapshotData.index = contextObject.tracks.total // not used
+                    waitForEndSnapshotData.index = app.controller.playbackState.contextDetails.tracks.total // not used
                     waitForEndSnapshotData.trackUri = event.trackUri
                 } else
                     currentSnapshotId = event.snapshotId
@@ -953,21 +814,16 @@ Page {
                 //currentSnapshotId = event.snapshotId
                 break
             case Util.PlaylistEventType.ReplacedAllTracks:
-                if(_isPlaying)
-                    app.pause(function(error, data) {
+                if(app.controller.playbackState.is_playing)
+                    app.controller.pause(function(error, data) {
                         currentId = "" // trigger reload)
-                        playContext({uri: contextObject.uri})
+                        playContext({uri: app.controller.playbackState.contextDetails.uri})
                     })
                 else
                     loadPlaylistTracks(app.id, currentId)
                 break
             }
         }
-    }
-
-    Component.onCompleted: {
-        if(app.hasValidToken)
-            refreshPlaybackState()
     }
 
     onStatusChanged: {

--- a/qml/pages/Playlist.qml
+++ b/qml/pages/Playlist.qml
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2018 Willem-Jan de Hoog
+ * Copyright (C) 2018 Maciej Janiszewski
  *
  * License: MIT
  */
@@ -74,7 +75,7 @@ Page {
                 onPaintedHeightChanged: height = Math.min(parent.width, paintedHeight)
                 MouseArea {
                      anchors.fill: parent
-                     onClicked: app.playContext(playlist)
+                     onClicked: app.controller.playContext(playlist)
                 }
             }
 


### PR DESCRIPTION
Moved most of the logic for managing playbackState, controlling playback and MPRIS stuff to SpotifyController component.

The idea is to unclutter hutspot.qml and make it easier to maintain only one, up to date copy of playbackState, instead of having the same code repeated in both hutspot.qml and on Playing.qml page.

@wdehoog please let me know if I didn't break any feature, I'm not familiar with your most recent changes.