### PR TITLE
New playing page design

### DIFF
--- a/hutspot.pro
+++ b/hutspot.pro
@@ -62,7 +62,8 @@ DISTFILES += \
     qml/components/QueueController.qml \
     qml/components/SpotifyController.qml \
     qml/components/PlaybackState.qml \
-    qml/components/ControlPanel.qml
+    qml/components/ControlPanel.qml \
+    qml/components/GlassyBackground.qml
 
 SAILFISHAPP_ICONS = 86x86 108x108 128x128 256x256
 

--- a/qml/components/GlassyBackground.qml
+++ b/qml/components/GlassyBackground.qml
@@ -1,0 +1,28 @@
+import QtQuick 2.1
+import Sailfish.Silica 1.0
+
+Rectangle {
+    property alias source: backgroundImage.source
+    property alias sourceSize: backgroundImage.sourceSize
+    property real dimmedOpacity: 0.15
+    color: "#000"
+
+    Image {
+        id: backgroundImage
+        cache: true
+        smooth: false
+        asynchronous: true
+        fillMode: Image.PreserveAspectCrop
+        anchors.fill: parent
+        visible: parent.visible
+        opacity: dimmedOpacity
+    }
+
+    Image {
+        anchors.fill: parent
+        fillMode:  Image.Tile
+        source: "image://theme/graphic-shader-texture"
+        opacity: 0.1
+        visible: parent.visible
+    }
+}

--- a/qml/components/LoadPushMenus.qml
+++ b/qml/components/LoadPushMenus.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 PushUpMenu {
+    enabled: cursorHelper.canLoadPrevious && cursorHelper.canLoadNext
     MenuItem {
         text: qsTr("Load Next Set")
         enabled: cursorHelper.canLoadNext

--- a/qml/hutspot.qml
+++ b/qml/hutspot.qml
@@ -26,6 +26,55 @@ ApplicationWindow {
         id: spotifyController
     }
 
+    GlassyBackground {
+        z: -1
+        id: glassyBackground
+        property bool showTrackInfo: true
+        anchors.fill: parent
+        sourceSize.height: parent.height
+        source: app.controller.getCoverArt("", showTrackInfo)
+        visible: source !== ""
+        // TODO: make some cool transitions
+        state: "Hidden"
+        opacity: 0
+        states: [
+            State {
+                name: "Hidden"
+                PropertyChanges { target: glassyBackground; opacity: 0}
+            },
+            State {
+                name: "Visible"
+                PropertyChanges { target: glassyBackground; opacity: 1}
+            }
+        ]
+
+        transitions: [
+            Transition {
+                from: "Hidden"
+                to: "Visible"
+                NumberAnimation {
+                    target: glassyBackground
+                    duration: 500
+                    from: 0
+                    to: 1
+                    properties: "opacity"
+                }
+            },
+            Transition {
+                from: "Visible"
+                to: "Hidden"
+                NumberAnimation {
+                    target: glassyBackground
+                    duration: 500
+                    from: 1
+                    to: 0
+                    properties: "opacity"
+                }
+            }
+        ]
+    }
+    property alias glassyBackground: glassyBackground
+
     property string connectionText: qsTr("connecting")
     property alias searchLimit: searchLimit
 

--- a/qml/pages/Devices.qml
+++ b/qml/pages/Devices.qml
@@ -20,8 +20,11 @@ Page {
         id: listView
 
         width: parent.width
-        anchors.top: parent.top
-        height: parent.height - app.dockedPanel.visibleSize
+        anchors {
+            top: parent.top
+            bottom: controlPanel.top
+        }
+
         clip: app.dockedPanel.expanded
 
         model: app.controller.devices
@@ -112,8 +115,43 @@ Page {
         VerticalScrollDecorator {}
     }
 
-    // signal foundDevicesChanged()
-    // onFoundDevicesChanged: refreshDevices()
+    PanelBackground {
+        id: controlPanel
+        x: 0
+        y: parent.height - height - app.dockedPanel.visibleSize
+        width: parent.width
+        height: volumeSlider.height
+
+        Image {
+            id: speakerIcon
+            x: Theme.horizontalPageMargin
+            source: volumeSlider.value <= 0 ? "image://theme/icon-m-speaker-mute" : "image://theme/icon-m-speaker"
+            anchors.verticalCenter: parent.verticalCenter
+            sourceSize {
+                width: Theme.iconSizeSmall
+                height: Theme.iconSizeSmall
+            }
+            height: Theme.iconSizeSmall
+        }
+
+        Slider {
+            id: volumeSlider
+            anchors {
+                left: speakerIcon.right
+                right: parent.right
+            }
+            minimumValue: 0
+            maximumValue: 100
+            handleVisible: false
+            value: app.controller.playbackState.device.volume_percent
+            onReleased: {
+                Spotify.setVolume(Math.round(value), function(error, data) {
+                    if(!error)
+                        app.controller.refreshPlaybackState();
+                })
+            }
+        }
+    }
 
     Connections {
         target: app

--- a/qml/pages/Playing.qml
+++ b/qml/pages/Playing.qml
@@ -7,6 +7,7 @@
 
 
 import QtQuick 2.2
+import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 
 import "../components"
@@ -77,17 +78,32 @@ Page {
                     MenuButton {}
                 }
 
-                Image {
-                    id: imageItem
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    source:  app.controller.getCoverArt(defaultImageSource, showTrackInfo)
-                    width: parent.width * 0.75
-                    height: width
-                    fillMode: Image.PreserveAspectFit
-                    onPaintedHeightChanged: height = Math.min(parent.width, paintedHeight)
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: showTrackInfo = !showTrackInfo
+                Item {
+                    width: parent.width
+                    height: imageItem.height
+
+                    Image {
+                        id: imageItem
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        width: parent.width * 0.75
+                        height: sourceSize.height*(width/sourceSize.width)
+                        source:  app.controller.getCoverArt(defaultImageSource, showTrackInfo)
+                        fillMode: Image.PreserveAspectFit
+                        onPaintedHeightChanged: parent.height = Math.min(parent.parent.width, paintedHeight)
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                showTrackInfo = !showTrackInfo
+                                app.glassyBackground.showTrackInfo = showTrackInfo
+                            }
+                        }
+                    }
+                    DropShadow {
+                        anchors.fill: imageItem
+                        radius: 3.0
+                        samples: 10
+                        color: "#000"
+                        source: imageItem
                     }
                 }
 
@@ -902,13 +918,17 @@ Page {
     // and some ListView events
     propagateComposedEvents: true
     onStatusChanged: {
-        //if(status === PageStatus.Active && app.playing_as_attached_page.value)
-        //    pageStack.pushAttached(Qt.resolvedUrl("NavigationMenu.qml"), {popOnExit: false})
-
-        if(status === PageStatus.Activating)
+        switch (status) {
+        case PageStatus.Activating:
+            app.glassyBackground.state = "Visible"
             app.dockedPanel.setHidden()
-        else if(status === PageStatus.Deactivating)
+            break;
+        case PageStatus.Deactivating:
             app.dockedPanel.resetHidden()
+            break;
+        case PageStatus.Inactive:
+            app.glassyBackground.state = "Hidden"
+            break;
+        }
     }
-
 }

--- a/qml/pages/Playing.qml
+++ b/qml/pages/Playing.qml
@@ -348,58 +348,11 @@ Page {
                 }
             }
 
-            // This works but Spotify has no 'mute' so maybe we should not do it as well
-            /*Item {
+            Rectangle {
                 width: parent.width
-                height: Math.max(muteIcon.height, volumeSlider.height)
-
-                Image {
-                    id: muteIcon
-                    anchors.left: parent.left
-                    anchors.verticalCenter: parent.verticalCenter
-                    source: muted ? "image://theme/icon-m-speaker" : "image://theme/icon-m-speaker-mute"
-                    MouseArea {
-                         anchors.fill: parent
-                         onClicked: {
-                             if(muted) {
-                                 Spotify.setVolume(mutedVolume, function(error, data) {
-                                     if(!error) {
-                                         volumeSlider.value = mutedVolume
-                                         app.controller.refreshPlaybackState()
-                                     }
-                                 })
-                             } else {
-                                 mutedVolume = volumeSlider.value
-                                 Spotify.setVolume(0, function(error, data) {
-                                     if(!error) {
-                                         volumeSlider.value = 0
-                                         app.controller.refreshPlaybackState()
-                                     }
-                                 })
-                             }
-                             muted = !muted
-                         }
-                    }
-                }*/
-
-                Slider {
-                    id: volumeSlider
-                    width: parent.width
-                    /*anchors.left: muteIcon.right
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter*/
-                    minimumValue: 0
-                    maximumValue: 100
-                    handleVisible: false
-                    value: app.controller.playbackState.device.volume_percent
-                    onReleased: {
-                        Spotify.setVolume(Math.round(value), function(error, data) {
-                            if(!error)
-                                app.controller.refreshPlaybackState();
-                        })
-                    }
-                }
-            /*}*/
+                height: Theme.paddingLarge
+                color: "transparent"
+            }
 
             Row {
                 id: buttonRow
@@ -408,36 +361,91 @@ Page {
 
                 IconButton {
                     width: buttonRow.itemWidth
-                    // enabled: app.mprisPlayer.canGoPrevious
+                    icon.source: app.controller.playbackState.shuffle_state
+                                 ? "image://theme/icon-m-shuffle?" + Theme.highlightColor
+                                 : "image://theme/icon-m-shuffle"
+                    onClicked: app.controller.setShuffle(!app.controller.playbackState.shuffle_state)
+                }
+
+                IconButton {
+                    width: buttonRow.itemWidth
+                    //enabled: app.mprisPlayer.canGoPrevious
                     icon.source: "image://theme/icon-m-previous"
                     onClicked: app.controller.previous()
                 }
                 IconButton {
                     width: buttonRow.itemWidth
                     icon.source: app.controller.playbackState.is_playing
-                                 ? "image://theme/icon-cover-pause"
-                                 : "image://theme/icon-cover-play"
+                                 ? "image://theme/icon-l-pause"
+                                 : "image://theme/icon-l-play"
                     onClicked: app.controller.playPause()
                 }
                 IconButton {
                     width: buttonRow.itemWidth
-                    // enabled: app.mprisPlayer.canGoNext
+                    //enabled: app.mprisPlayer.canGoNext
                     icon.source: "image://theme/icon-m-next"
                     onClicked: app.controller.next()
                 }
                 IconButton {
+                    Rectangle {
+                        visible: app.controller.playbackState.repeat_state === "track"
+                        color: Theme.highlightColor
+                        anchors {
+                            rightMargin: (buttonRow.itemWidth - Theme.iconSizeMedium)/2
+                            right: parent.right
+                            top: parent.top
+                        }
+                        width: Theme.iconSizeSmall
+                        height: width
+                        radius: width/2
+
+                        Label {
+                            text: "1"
+                            anchors.centerIn: parent
+                            color: "#000"
+                            font.pixelSize: Theme.fontSizeSmall
+                            font.bold: true
+                        }
+                    }
+
                     width: buttonRow.itemWidth
-                    icon.source: (app.controller.playbackState && app.controller.playbackState.repeat_state)
+                    icon.source: app.controller.playbackState.repeat_state !== "off"
                                  ? "image://theme/icon-m-repeat?" + Theme.highlightColor
                                  : "image://theme/icon-m-repeat"
-                    onClicked: app.controller.setRepeat(checked)
+                    onClicked: app.controller.setRepeat(app.controller.playbackState.nextRepeatState())
                 }
-                IconButton {
-                    width: buttonRow.itemWidth
-                    icon.source: (app.controller.playbackState && app.controller.playbackState.shuffle_state)
-                                 ? "image://theme/icon-m-shuffle?" + Theme.highlightColor
-                                 : "image://theme/icon-m-shuffle"
-                    onClicked: app.controller.setShuffle(checked)
+            }
+
+            Rectangle {
+                width: parent.width
+                height: Theme.paddingLarge
+                color: "transparent"
+            }
+
+            Item {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: spotifyConnectRow.childrenRect.height + Theme.paddingLarge*2
+                MouseArea {
+                    anchors.fill: spotifyConnectRow
+                    onClicked: pageStack.push(Qt.resolvedUrl("../pages/Devices.qml"))
+                }
+
+                Row {
+                    id: spotifyConnectRow
+                    y: Theme.paddingLarge
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: Theme.paddingMedium
+                    Image {
+                        anchors.verticalCenter: spotifyConnectLabel.verticalCenter
+                        source: "image://theme/icon-cover-play"
+                    }
+
+                    Label {
+                        id: spotifyConnectLabel
+                        text: app.controller.playbackState.device !== undefined ? "Listening on <b>" + app.controller.playbackState.device.name + "</b>" : ""
+                    }
+                    visible: app.controller.playbackState.device !== undefined
                 }
             }
         }


### PR DESCRIPTION
I moved over some changes from design_ideas branch.
- cover art as ambiance on playing page
- volume slider moved to Devices page, replaced with device indicator on Playing page for easier access
- new controls from design_ideas
- drop shadow near cover art

Known issues:
- weird transition effect on Devices page

![zrzut_ekranu_20181018_001](https://user-images.githubusercontent.com/1162358/47149428-d51a4080-d2d3-11e8-9808-08be9eb2dc16.png)